### PR TITLE
Update runprime to not overwrite prime.txt and local.txt 

### DIFF
--- a/runprime
+++ b/runprime
@@ -8,7 +8,8 @@
 
 [ -d "prime" ] || mkdir prime
 
-cat <<-EOF > prime/prime.txt
+# Don't overwrite prime.txt file if it already exists!
+[ -f "prime/prime.txt" ] || { cat <<-EOF > prime/prime.txt
 V24OptionsConverted=1
 WGUID_version=2
 StressTester=0
@@ -22,10 +23,13 @@ WorkPreference=0
 Debug=0
 ProxyHost=
 EOF
+}
 
-cat <<-EOF > prime/local.txt
+# Don't overwrite local.txt file if it already exists!
+[ -f "prime/local.txt" ] || { cat <<-EOF > prime/local.txt
 ComputerID=$HOSTNAME
 EOF
+}
 
 mprime -wprime
 


### PR DESCRIPTION
Update runprime to not overwrite prime.txt and local.txt if they already exist.

Without this update the existing prime.txt and local.txt files are overwritten if the Docker container is restarted.  This update only creates the prime.txt and local.txt files if they do not exist.
